### PR TITLE
add documentation for quality in savefig

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1811,6 +1811,14 @@ default: 'top'
         dpi : [ *None* | scalar > 0 | 'figure' ]
             The resolution in dots per inch.  If *None*, defaults to
             :rc:`savefig.dpi`.  If 'figure', uses the figure's dpi value.
+        
+        quality : [ *None* | 95 >= scalar >= 1 ]
+            The image quality, on a scale from 1 (worst) to 95 (best).
+            Applicable only if *format* is jpg or jpeg, ignored otherwise.
+            If *None*, defaults to :rc:`savefig.jpeg_quality` (95 by default).
+            Values above 95 should be avoided; 100 completely disables the
+            JPEG quantization stage.
+             
 
         facecolor : color spec or None, optional
             The facecolor of the figure; if *None*, defaults to


### PR DESCRIPTION
#458
based on the discussion here https://github.com/matplotlib/matplotlib/issues/458
and also using some of the lines from
https://matplotlib.org/api/backend_agg_api.html?highlight=print_jpeg#matplotlib.backends.backend_agg.FigureCanvasAgg.print_jpeg

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is PEP 8 compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
